### PR TITLE
update lib.rs

### DIFF
--- a/src/icp_rust_boilerplate_backend/src/lib.rs
+++ b/src/icp_rust_boilerplate_backend/src/lib.rs
@@ -17,7 +17,7 @@ struct NFTCertificate {
     created_at: u64,
 }
 
-// a trait that must be implemented for a struct that is stored in a stable struct
+// A trait that must be implemented for a struct that is stored in a stable struct
 impl Storable for NFTCertificate {
     fn to_bytes(&self) -> std::borrow::Cow<[u8]> {
         Cow::Owned(Encode!(self).unwrap())
@@ -28,7 +28,7 @@ impl Storable for NFTCertificate {
     }
 }
 
-// another trait that must be implemented for a struct that is stored in a stable struct
+// Another trait that must be implemented for a struct that is stored in a stable struct
 impl BoundedStorable for NFTCertificate {
     const MAX_SIZE: u32 = 1024;
     const IS_FIXED_SIZE: bool = false;
@@ -61,30 +61,46 @@ fn get_nft(id: u64) -> Result<NFTCertificate, Error> {
     match _get_nft(&id) {
         Some(nft) => Ok(nft),
         None => Err(Error::NotFound {
-            msg: format!("an NFT with id={} not found", id),
+            msg: format!("An NFT with id={} not found", id),
         }),
     }
 }
 
+// Validate NFTPayload before processing
+fn validate_payload(payload: &NFTPayload) -> Result<(), Error> {
+    if payload.owner.trim().is_empty() {
+        return Err(Error::InvalidInput { msg: "Owner is required".to_string() });
+    }
+    if payload.metadata.trim().is_empty() {
+        return Err(Error::InvalidInput { msg: "Metadata is required".to_string() });
+    }
+    Ok(())
+}
+
 #[ic_cdk::update]
-fn create_nft(payload: NFTPayload) -> Option<NFTCertificate> {
+fn create_nft(payload: NFTPayload) -> Result<NFTCertificate, Error> {
+    // Validate the payload
+    validate_payload(&payload)?;
+
     let id = ID_COUNTER
         .with(|counter| {
             let current_value = *counter.borrow().get();
             counter.borrow_mut().set(current_value + 1)
         })
-        .expect("cannot increment id counter");
+        .expect("Cannot increment ID counter");
+    
     let nft = NFTCertificate {
         id,
         owner: payload.owner,
         metadata: payload.metadata,
         created_at: time(),
     };
+
     do_insert(&nft);
-    Some(nft)
+    Ok(nft)
 }
 
-// helper method to perform insert.
+// Helper method to perform insert
 fn do_insert(nft: &NFTCertificate) {
     STORAGE.with(|service| service.borrow_mut().insert(nft.id, nft.clone()));
 }
@@ -94,10 +110,7 @@ fn delete_nft(id: u64) -> Result<NFTCertificate, Error> {
     match STORAGE.with(|service| service.borrow_mut().remove(&id)) {
         Some(nft) => Ok(nft),
         None => Err(Error::NotFound {
-            msg: format!(
-                "couldn't delete an NFT with id={}. NFT not found.",
-                id
-            ),
+            msg: format!("Couldn't delete an NFT with id={}. NFT not found.", id),
         }),
     }
 }
@@ -105,12 +118,13 @@ fn delete_nft(id: u64) -> Result<NFTCertificate, Error> {
 #[derive(candid::CandidType, Deserialize, Serialize)]
 enum Error {
     NotFound { msg: String },
+    InvalidInput { msg: String },
 }
 
-// a helper method to get an NFT by id. used in get_nft
+// Helper method to get an NFT by id, used in get_nft
 fn _get_nft(id: &u64) -> Option<NFTCertificate> {
     STORAGE.with(|service| service.borrow().get(id))
 }
 
-// need this to generate candid
+// Need this to generate candid
 ic_cdk::export_candid!();


### PR DESCRIPTION
Here are the changes made to the code:

1. **Added Payload Validation**:
   - Introduced a `validate_payload` function to check the `NFTPayload` fields (`owner` and `metadata`) to ensure they are not empty or only whitespace.

2. **Implemented Validation in `create_nft`**:
   - Before creating an NFT, the `validate_payload` function is called within `create_nft`. If validation fails, the process is aborted and an error is returned.

3. **Extended the `Error` Enum**:
   - A new `InvalidInput` variant was added to the `Error` enum to handle cases where the input validation fails. It carries a message that explains why the validation failed (e.g., missing owner or metadata).

4. **Updated Return Type in `create_nft`**:
   - Changed the return type of `create_nft` from `Option<NFTCertificate>` to `Result<NFTCertificate, Error>`, so it can return specific error messages (like validation errors) instead of just `None`.

These changes improve the robustness of the function by preventing the creation of NFTs with invalid or incomplete data.